### PR TITLE
Fix yt-dlp video format selection

### DIFF
--- a/src/core/youtube.ts
+++ b/src/core/youtube.ts
@@ -185,7 +185,7 @@ export async function downloadVideo(
       [
         ...getYtDlpCookiesArgs(config, tempCookiePath),
         "-f",
-        "bestvideo[height<=1080][ext=mp4]+bestaudio[ext=m4a]/best[height<=1080][ext=mp4]/best",
+        "bestvideo[height<=1080]+bestaudio/best[height<=1080]/best",
         "--merge-output-format",
         "mp4",
         "-o",

--- a/src/core/youtube.ts
+++ b/src/core/youtube.ts
@@ -185,7 +185,7 @@ export async function downloadVideo(
       [
         ...getYtDlpCookiesArgs(config, tempCookiePath),
         "-f",
-        "bestvideo[height<=1080]+bestaudio/best[height<=1080]/best",
+        "bestvideo[height<=1080]+bestaudio/bestvideo+bestaudio/best",
         "--merge-output-format",
         "mp4",
         "-o",


### PR DESCRIPTION
Fixes an issue where downloading YouTube videos failed with `Requested format is not available` error by making the `yt-dlp` format selection more flexible.

---
*PR created automatically by Jules for task [621000189547058026](https://jules.google.com/task/621000189547058026) started by @juninmd*