### PR TITLE
fix: resolve telegram markdown errors and update github action inputs

### DIFF
--- a/.github/workflows/generate-shorts.yml
+++ b/.github/workflows/generate-shorts.yml
@@ -126,7 +126,9 @@ jobs:
 
       - name: Override channels (if provided)
         if: ${{ inputs.channels }}
-        run: echo "YOUTUBE_CHANNELS=${{ inputs.channels }}" >> $GITHUB_ENV
+        run: echo "YOUTUBE_CHANNELS=$INPUT_CHANNELS" >> $GITHUB_ENV
+        env:
+          INPUT_CHANNELS: ${{ inputs.channels }}
 
       - name: Run shorts generation
         run: pnpm run generate

--- a/.github/workflows/generate-shorts.yml
+++ b/.github/workflows/generate-shorts.yml
@@ -32,14 +32,14 @@ env:
   OLLAMA_MODEL: ${{ vars.OLLAMA_MODEL || 'qwen3:1.7b' }}
   WHISPER_MODEL: ${{ vars.WHISPER_MODEL || 'base' }}
   # For hourly runs, only fetch videos from the last hour (0 = today, fine-grained via upload_date)
-  DAYS_BACK: ${{ github.event.inputs.days_back || vars.DAYS_BACK || '0' }}
-  VIDEO_URLS: ${{ github.event.inputs.video_urls || '' }}
+  DAYS_BACK: ${{ inputs.days_back || vars.DAYS_BACK || '0' }}
+  VIDEO_URLS: ${{ inputs.video_urls || '' }}
   OUTPUT_DIR: ./output
   PIP_CACHE_DIR: ~/.cache/pip
   WHISPER_CACHE_DIR: ~/.cache/whisper
   OLLAMA_MODELS_DIR: ~/.ollama/models
   YOUTUBE_COOKIES_BASE64: ${{ secrets.YOUTUBE_COOKIES_BASE64 }}
-  WATERMARK_TEXT: ${{ github.event.inputs.watermark_text || vars.WATERMARK_TEXT || 'santidade católica' }}
+  WATERMARK_TEXT: ${{ inputs.watermark_text || vars.WATERMARK_TEXT || 'santidade católica' }}
   # Safety limits
   MAX_VIDEO_SIZE_MB: ${{ vars.MAX_VIDEO_SIZE_MB || '500' }}
   MIN_SHORTS_PER_VIDEO: ${{ vars.MIN_SHORTS_PER_VIDEO || '2' }}
@@ -125,8 +125,8 @@ jobs:
           ollama --version
 
       - name: Override channels (if provided)
-        if: ${{ github.event.inputs.channels }}
-        run: echo "YOUTUBE_CHANNELS=${{ github.event.inputs.channels }}" >> $GITHUB_ENV
+        if: ${{ inputs.channels }}
+        run: echo "YOUTUBE_CHANNELS=${{ inputs.channels }}" >> $GITHUB_ENV
 
       - name: Run shorts generation
         run: pnpm run generate

--- a/src/core/telegram.ts
+++ b/src/core/telegram.ts
@@ -6,9 +6,9 @@ import { logger } from "./logger.js";
 function escapeHtml(text: string): string {
   if (!text) return "";
   return text
-    .replace(/&/g, "&amp;")
-    .replace(/</g, "&lt;")
-    .replace(/>/g, "&gt;");
+    .replaceAll("&", "&amp;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;");
 }
 
 /**
@@ -104,7 +104,7 @@ export async function sendSummary(
     `🎥 Vídeo: ${escapeHtml(videoTitle)}`,
     `✂️ Shorts gerados: ${shortsCount}`,
     errors.length > 0 ? `❌ Erros: ${errors.length}` : "",
-    errors.length > 0 ? `\n${errors.map((e) => `• ${escapeHtml(e)}`).join("\n")}` : "",
+    errors.length > 0 ? "\n" + errors.map((e) => `• ${escapeHtml(e)}`).join("\n") : "",
   ]
     .filter(Boolean)
     .join("\n");

--- a/src/core/telegram.ts
+++ b/src/core/telegram.ts
@@ -37,7 +37,7 @@ export async function sendToTelegram(
     ``,
     `📺 Canal: ${escapeHtml(short.channelName)}`,
     `🎥 Vídeo original: ${escapeHtml(short.originalVideoTitle)}`,
-    `🔗 ${escapeHtml(short.originalVideoUrl)}`,
+    `🔗 <a href="${short.originalVideoUrl}">${escapeHtml(short.originalVideoUrl)}</a>`,
     `⏱ Corte: ${timeRange}`,
     `⭐ Score viral: ${short.clip.viralScore}/10`,
     ``,

--- a/src/core/telegram.ts
+++ b/src/core/telegram.ts
@@ -3,6 +3,14 @@ import fs from "node:fs";
 import type { GeneratedShort, PipelineConfig } from "../types.js";
 import { logger } from "./logger.js";
 
+function escapeHtml(text: string): string {
+  if (!text) return "";
+  return text
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;");
+}
+
 /**
  * Send a generated short to a Telegram channel.
  */
@@ -25,17 +33,17 @@ export async function sendToTelegram(
   const timeRange = `${startMin}:${startSec.toString().padStart(2, "0")} - ${endMin}:${endSec.toString().padStart(2, "0")}`;
 
   const caption = [
-    `🎬 **${short.clip.title}**`,
+    `🎬 <b>${escapeHtml(short.clip.title)}</b>`,
     ``,
-    `📺 Canal: ${short.channelName.replace(/[@_]/g, "\\$&")}`,
-    `🎥 Vídeo original: ${short.originalVideoTitle}`,
-    `🔗 ${short.originalVideoUrl}`,
+    `📺 Canal: ${escapeHtml(short.channelName)}`,
+    `🎥 Vídeo original: ${escapeHtml(short.originalVideoTitle)}`,
+    `🔗 ${escapeHtml(short.originalVideoUrl)}`,
     `⏱ Corte: ${timeRange}`,
     `⭐ Score viral: ${short.clip.viralScore}/10`,
     ``,
-    `💡 ${short.clip.reason}`,
+    `💡 ${escapeHtml(short.clip.reason)}`,
     ``,
-    short.clip.hashtags.map((h) => (h.startsWith("#") ? h : `#${h}`)).join(" "),
+    short.clip.hashtags.map((h) => (h.startsWith("#") ? h : `#${h}`)).map(escapeHtml).join(" "),
   ].join("\n");
 
   try {
@@ -48,7 +56,7 @@ export async function sendToTelegram(
         "Video too large for Telegram, sending link instead",
       );
       const msg = await bot.api.sendMessage(config.telegramChatId, caption, {
-        parse_mode: "Markdown",
+        parse_mode: "HTML",
       });
       return msg.message_id;
     }
@@ -56,7 +64,7 @@ export async function sendToTelegram(
     const videoFile = new InputFile(short.outputPath);
     const msg = await bot.api.sendVideo(config.telegramChatId, videoFile, {
       caption,
-      parse_mode: "Markdown",
+      parse_mode: "HTML",
       supports_streaming: true,
     });
 
@@ -89,21 +97,21 @@ export async function sendSummary(
   const status = errors.length === 0 ? "✅ Sucesso" : "⚠️ Com erros";
 
   const message = [
-    `📊 **Resumo do processamento**`,
+    `📊 <b>Resumo do processamento</b>`,
     ``,
     `${status}`,
-    `📺 Canal: ${channelName.replace(/[@_]/g, "\\$&")}`,
-    `🎥 Vídeo: ${videoTitle}`,
+    `📺 Canal: ${escapeHtml(channelName)}`,
+    `🎥 Vídeo: ${escapeHtml(videoTitle)}`,
     `✂️ Shorts gerados: ${shortsCount}`,
     errors.length > 0 ? `❌ Erros: ${errors.length}` : "",
-    errors.length > 0 ? `\n${errors.map((e) => `• ${e}`).join("\n")}` : "",
+    errors.length > 0 ? `\n${errors.map((e) => `• ${escapeHtml(e)}`).join("\n")}` : "",
   ]
     .filter(Boolean)
     .join("\n");
 
   try {
     await bot.api.sendMessage(config.telegramChatId, message, {
-      parse_mode: "Markdown",
+      parse_mode: "HTML",
     });
   } catch (error) {
     logger.error({ error }, "Failed to send summary to Telegram");


### PR DESCRIPTION
This PR fixes two issues that caused the GitHub actions pipeline to stop successfully generating and sending videos to Telegram:

1. **Telegram API Formatting Errors:** Due to Telegram's strict parsing of `Markdown` formatted messages, any unescaped special characters (e.g., `_`, `*`, `[`) in video titles, channel names, or generated AI text would result in a `400 Bad Request` from the Telegram API, causing the application to fail to send the video. To resolve this, the message generation was updated to use `parse_mode: 'HTML'` and an `escapeHtml` function was added to sanitize all dynamic text.
2. **GitHub Actions Input Evaluation:** The workflow was incorrectly accessing inputs via `${{ github.event.inputs }}` even though the workflow is also scheduled via cron (where `github.event.inputs` is empty). The workflow variables were updated to use the robust `${{ inputs }}` context, ensuring inputs correctly fallback to repository variables.

---
*PR created automatically by Jules for task [18122082824808669764](https://jules.google.com/task/18122082824808669764) started by @juninmd*