### PR TITLE
feat: Improve viral algorithm, cuts generation logic, and tiny watermark

### DIFF
--- a/src/core/analyzer.ts
+++ b/src/core/analyzer.ts
@@ -275,7 +275,7 @@ You must find between **${minClips} and ${maxClips} clips**. Do not generate few
 - Each clip must be between **${minDuration}** and **${maxDuration} seconds**
 - Clips must NOT overlap
 - startTime and endTime MUST perfectly align with transcript segment boundaries
-- Generate extreme, extremely clickbaity, and punchy titles IN PORTUGUESE (PT-BR) that provoke intense curiosity, urgency, or FOMO. Titles MUST be highly attractive for TikTok/Shorts algorithms and guarantee virality.
+- Generate extreme, EXTREMELY clickbaity, and punchy titles IN PORTUGUESE (PT-BR) that provoke intense curiosity, urgency, or FOMO. Titles MUST be highly attractive for TikTok/Shorts algorithms, practically forcing the user to click. Emphasize controversy or mind-blowing facts in the title.
 
 ## Transcript:
 ${transcript}

--- a/src/core/config.ts
+++ b/src/core/config.ts
@@ -74,10 +74,9 @@ export function loadConfig(overrides?: Partial<PipelineConfig>): PipelineConfig 
  */
 export function getMaxCuts(videoDurationSeconds: number): number {
   const durationMinutes = Math.floor(videoDurationSeconds / 60);
-  return Math.max(1, durationMinutes);
+  return Math.max(2, durationMinutes);
 }
 
 export function getMinCuts(videoDurationSeconds: number): number {
-  const durationMinutes = Math.floor(videoDurationSeconds / 60);
-  return Math.max(2, durationMinutes * 2);
+  return 2;
 }

--- a/src/core/video-processor.ts
+++ b/src/core/video-processor.ts
@@ -95,7 +95,7 @@ function renderShort(
 
     if (watermarkText) {
       // Bottom right corner, well small
-      filters.push(`drawtext=text='${watermarkText}':x=w-tw-5:y=h-th-5:fontsize=12:fontcolor=white@0.5:shadowcolor=black@0.5:shadowx=1:shadowy=1`);
+      filters.push(`drawtext=text='${watermarkText}':x=w-tw-5:y=h-th-5:fontsize=10:fontcolor=white@0.5:shadowcolor=black@0.5:shadowx=1:shadowy=1`);
     }
 
     const videoFilter = filters.join(",");

--- a/tests/core/config.test.ts
+++ b/tests/core/config.test.ts
@@ -43,17 +43,17 @@ describe("config", () => {
 
   describe("getMaxCuts", () => {
     it("should calculate max cuts based on minutes", () => {
-      expect(getMaxCuts(60)).toBe(1); // 1 min -> 1
+      expect(getMaxCuts(60)).toBe(2); // 1 min -> 2 (min bound)
       expect(getMaxCuts(300)).toBe(5); // 5 min -> 5
-      expect(getMaxCuts(30)).toBe(1); // 0.5 min -> max(1, 0) = 1
+      expect(getMaxCuts(30)).toBe(2); // 0.5 min -> max(2, 0) = 2
     });
   });
 
   describe("getMinCuts", () => {
-    it("should calculate min cuts based on 2 per minute", () => {
-      expect(getMinCuts(60)).toBe(2); // 1 min -> 2
-      expect(getMinCuts(300)).toBe(10); // 5 min -> 10
-      expect(getMinCuts(30)).toBe(2); // 0.5 min -> max(2, 0) = 2
+    it("should return a fixed minimum of 2", () => {
+      expect(getMinCuts(60)).toBe(2);
+      expect(getMinCuts(300)).toBe(2);
+      expect(getMinCuts(30)).toBe(2);
     });
   });
 

--- a/tests/core/video-processor.test.ts
+++ b/tests/core/video-processor.test.ts
@@ -97,7 +97,7 @@ describe("video-processor", () => {
     // Verify watermark in videoFilters
     const videoFiltersCall = vi.mocked(ffmpegModule.default().videoFilters).mock.calls[0];
     const filtersParam = videoFiltersCall[0] as string;
-    expect(filtersParam).toContain("drawtext=text='Test Watermark':x=w-tw-5:y=h-th-5:fontsize=12");
+    expect(filtersParam).toContain("drawtext=text='Test Watermark':x=w-tw-5:y=h-th-5:fontsize=10");
   });
 
   it("processClip should handle ffmpeg start, progress, and error events", async () => {


### PR DESCRIPTION
- Updated the LLM prompt to heavily prioritize controversial, clickbaity titles in PT-BR.
- Tweaked the minimum and maximum cuts bounds to be `min=2` and `max=duration_in_minutes`.
- Changed the watermark `fontsize` parameter in the `ffmpeg` filter to 10 for a tinier, less obtrusive corner watermark that reads "santidade católica" by default.
- Added corresponding unit tests to verify the bounds constraints logic.

---
*PR created automatically by Jules for task [8195480571677550616](https://jules.google.com/task/8195480571677550616) started by @juninmd*