### PR TITLE
fix: update Ollama binary cache key in CI to support gemma3:1b

### DIFF
--- a/.github/workflows/generate-shorts.yml
+++ b/.github/workflows/generate-shorts.yml
@@ -120,7 +120,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: /usr/local/bin/ollama
-          key: ${{ runner.os }}-ollama-bin-v1
+          key: ${{ runner.os }}-ollama-bin-v2
 
       - name: Install Ollama
         if: steps.ollama-bin-cache.outputs.cache-hit != 'true'

--- a/.github/workflows/generate-top-shorts.yml
+++ b/.github/workflows/generate-top-shorts.yml
@@ -105,7 +105,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: /usr/local/bin/ollama
-          key: ${{ runner.os }}-ollama-bin-v1
+          key: ${{ runner.os }}-ollama-bin-v2
 
       - name: Install Ollama
         if: steps.ollama-bin-cache.outputs.cache-hit != 'true'

--- a/tests/core/youtube.service.test.ts
+++ b/tests/core/youtube.service.test.ts
@@ -113,7 +113,7 @@ describe("youtube.service", () => {
       await generateYoutubeMetadata(mockShort, configWithoutModel);
 
       expect(chatMock).toHaveBeenCalledWith(expect.objectContaining({
-        model: "qwen3:1.7b"
+        model: "gemma3:1b"
       }));
     });
 


### PR DESCRIPTION
Update the GitHub Actions workflows to ensure the latest version of the Ollama binary is downloaded so it supports the `gemma3:1b` model. Also update the outdated test case expecting `qwen3:1.7b` to correctly assert the use of `gemma3:1b` as the fallback model.

---
*PR created automatically by Jules for task [2730308860071074041](https://jules.google.com/task/2730308860071074041) started by @juninmd*