### PR TITLE
test(analyzer): ensure 100% test coverage for core AI processing modules

### DIFF
--- a/src/core/analyzer-chunks.ts
+++ b/src/core/analyzer-chunks.ts
@@ -1,4 +1,4 @@
-/* v8 ignore start */
+
 import { generateObject } from "ai";
 import type { Transcript, TranscriptSegment, PipelineConfig } from "../types.js";
 import { logger } from "./logger.js";
@@ -109,4 +109,3 @@ export async function analyzeInChunks(
 }
 
 export { ClipSchema, type ClipItem };
-/* v8 ignore stop */

--- a/src/core/analyzer.ts
+++ b/src/core/analyzer.ts
@@ -1,4 +1,4 @@
-/* v8 ignore start */
+
 import { generateObject } from "ai";
 import { nanoid } from "nanoid";
 import type { Transcript, ShortClip, TranscriptSegment, TranscriptWord, PipelineConfig } from "../types.js";
@@ -179,4 +179,3 @@ function getWordsInRange(words: TranscriptWord[], start: number, end: number): T
     .filter((w) => w.start >= start - 0.1 && w.end <= end + 0.1)
     .map((w) => ({ word: w.word, start: Math.max(0, w.start - start), end: w.end - start }));
 }
-/* v8 ignore stop */

--- a/tests/core/analyzer-chunks.test.ts
+++ b/tests/core/analyzer-chunks.test.ts
@@ -26,6 +26,11 @@ describe("analyzer-chunks", () => {
     expect(formatTranscriptForLLM(segments)).toBe("[00:01-00:05] Hello\n[00:06-00:10] World");
   });
 
+  it("splitIntoChunks processes empty segments", () => {
+    const chunks = splitIntoChunks([], 30, 1);
+    expect(chunks).toHaveLength(0);
+  });
+
   it("splitIntoChunks splits correctly and overlaps", () => {
     const segments = [
       { start: 1, end: 2, text: "A".repeat(10) },

--- a/tests/core/analyzer.test.ts
+++ b/tests/core/analyzer.test.ts
@@ -170,6 +170,55 @@ describe("analyzer", () => {
     expect(clips).toHaveLength(0);
   });
 
+  it("should return empty array if AI resolves without clips array", async () => {
+    vi.mocked(aiModule.generateObject).mockResolvedValue({
+      object: {}, // missing clips
+    } as any);
+
+    const clips = await analyzeTranscript(mockTranscript, "Title", "Channel", mockConfig);
+    expect(clips).toHaveLength(0);
+  });
+
+  it("should analyze in chunks if formatted transcript length exceeds CHUNK_THRESHOLD_CHARS", async () => {
+    // Generate segments so the formatted transcript > 32000 chars
+    const largeSegments = Array.from({ length: 600 }).map((_, i) => ({
+      start: i * 2,
+      end: i * 2 + 2,
+      text: "A very long sentence here to fill up the chunk threshold limit quickly ".repeat(3)
+    }));
+
+    const largeTranscript: Transcript = {
+      videoId: "vid1",
+      duration: 1200,
+      segments: largeSegments,
+      words: [],
+      fullText: "",
+      language: "pt",
+    };
+
+    const mockResponse = {
+      clips: [
+        {
+          title: "Clip Chunks",
+          description: "Desc",
+          startTime: 10,
+          endTime: 40,
+          viralScore: 9,
+          reason: "Reason",
+          hashtags: ["#test"],
+        },
+      ],
+    };
+
+    vi.mocked(aiModule.generateObject).mockResolvedValue({
+      object: mockResponse,
+    } as any);
+
+    const clips = await analyzeTranscript(largeTranscript, "Title", "Channel", mockConfig);
+    expect(clips).toHaveLength(1);
+    expect(clips[0].title).toBe("Clip Chunks");
+  });
+
   it("should correctly handle words within the clip range", async () => {
     const mockResponse = {
       clips: [


### PR DESCRIPTION
Removed file-wide `v8 ignore start/stop` flags from `src/core/analyzer.ts` and `src/core/analyzer-chunks.ts`.
Added unit tests to `tests/core/analyzer.test.ts` and `tests/core/analyzer-chunks.test.ts` to properly handle:
- Empty array processing during chunking
- Missing `clips` fallback logic when parsing the `generateObject` AI response
- Processing transcript chunks correctly when total characters exceed `CHUNK_THRESHOLD_CHARS`

---
*PR created automatically by Jules for task [683161214076919026](https://jules.google.com/task/683161214076919026) started by @juninmd*