### PR TITLE
feat: melhora posts YouTube e notificações Telegram

### DIFF
--- a/src/core/full-video-metadata.ts
+++ b/src/core/full-video-metadata.ts
@@ -1,0 +1,49 @@
+import type { PipelineConfig, VideoInfo } from "../types.js";
+
+// Channel-derived keyword tags: full channel name plus adjacent word-pairs
+// (handles "Nome Sobrenome Extra" → full + first-two + last-two). Lowercased,
+// with separator punctuation stripped so YouTube search matches cleanly.
+function deriveChannelTags(channelName: string): string[] {
+  const name = channelName.replace(/[|•·\-–—]+/g, " ").replace(/\s+/g, " ").trim();
+  if (!name) return [];
+  const words = name.split(" ").filter(Boolean);
+  const tags = [name.toLowerCase()];
+  if (words.length >= 2) {
+    tags.push(`${words[0]} ${words[1]}`.toLowerCase());
+    tags.push(`${words[words.length - 2]} ${words[words.length - 1]}`.toLowerCase());
+  }
+  return tags;
+}
+
+/**
+ * Engaging, well-formatted description for a full-video repost: teaser, CTA,
+ * original link and a hashtag block built from the channel name.
+ */
+export function buildFullVideoDescription(video: VideoInfo): string {
+  const tag = video.channelName.replace(/[^\p{L}\p{N}]/gu, "");
+  const firstWord = video.channelName.split(" ")[0]?.replace(/[^\p{L}\p{N}]/gu, "") || "";
+  return [
+    `🎬 ${video.title}`,
+    ``,
+    `Confira na íntegra este conteúdo do canal ${video.channelName}.`,
+    ``,
+    `👉 Inscreva-se e ative o sininho para não perder nada! Deixe seu like 👍 e comente o que achou.`,
+    ``,
+    `🎥 Vídeo original completo: ${video.url}`,
+    ``,
+    `#shorts #viral${tag ? ` #${tag}` : ""}${firstWord && firstWord !== tag ? ` #${firstWord}` : ""}`,
+  ].join("\n");
+}
+
+/**
+ * Search tags for a full-video repost: channel name + word-pairs + broad terms.
+ */
+export function buildFullVideoTags(video: VideoInfo, config: PipelineConfig): string[] {
+  return [
+    ...deriveChannelTags(video.channelName),
+    ...(config.managedRun?.focusLabels || []),
+    "viral",
+    "curiosidades",
+    "melhores momentos",
+  ];
+}

--- a/src/core/pipeline.ts
+++ b/src/core/pipeline.ts
@@ -7,6 +7,7 @@ import { uploadFullVideoToYouTube } from "./youtube.service.js";
 import { logger } from "./logger.js";
 import { isMusicVideoByTitle, isVideoWithinLimits, selectValidVideos, matchesVideoQuery } from "./pipeline-filters.js";
 import { processVideo } from "./pipeline-video-processor.js";
+import { buildFullVideoDescription, buildFullVideoTags } from "./full-video-metadata.js";
 
 export type { ProgressCallback } from "./pipeline-video-processor.js";
 export { processVideo };
@@ -51,8 +52,9 @@ export async function runTopVideoPipeline(
 
     const fullVideoPath = await downloadVideoSection(targetVideo, 0, targetVideo.duration, config);
     const downloadedFull = { ...downloaded, filePath: fullVideoPath };
-    const ytDescription = `Este é um repost do canal: ${targetVideo.channelName}\n\nAssista ao original aqui: ${targetVideo.url}`;
-    const youtubeUrl = await uploadFullVideoToYouTube(downloadedFull.filePath, targetVideo.title, ytDescription, config);
+    const ytDescription = buildFullVideoDescription(targetVideo);
+    const ytTags = buildFullVideoTags(targetVideo, config);
+    const youtubeUrl = await uploadFullVideoToYouTube(downloadedFull.filePath, targetVideo.title, ytDescription, config, ytTags);
 
     await sendFullVideoToTelegram(downloadedFull, config, youtubeUrl);
     if (!config.keepTempFiles) cleanupVideo(targetVideo.id, config);

--- a/src/core/telegram.ts
+++ b/src/core/telegram.ts
@@ -14,16 +14,50 @@ function escapeHtml(text: string): string {
 }
 
 /**
+ * Build a short, human-friendly preview of the tags applied to a YouTube upload.
+ * Caps the number shown so the Telegram message stays readable, and signals how
+ * many extra tags were sent beyond the preview.
+ */
+function formatTagsPreview(tags: string[] | undefined, maxShown = 12): string {
+  const clean = (tags || []).map((t) => (t ?? "").trim()).filter(Boolean);
+  if (clean.length === 0) return "";
+  const shown = clean.slice(0, maxShown);
+  const rest = clean.length - shown.length;
+  const list = shown.map((t) => escapeHtml(t)).join(", ");
+  return rest > 0 ? `${list} <i>(+${rest})</i>` : list;
+}
+
+/**
  * Notify Telegram that a video was published to YouTube, with thumbnail + link.
+ * Also surfaces the optimized title, a teaser from the description and the
+ * search tags that were actually applied to the upload.
  */
 export async function notifyYoutubePublished(
-  params: { videoId: string; url: string; title: string; channelName?: string | null; isShort: boolean },
+  params: {
+    videoId: string;
+    url: string;
+    title: string;
+    channelName?: string | null;
+    isShort: boolean;
+    tags?: string[];
+    description?: string;
+  },
   config: PipelineConfig,
 ): Promise<void> {
   if (!config.telegramBotToken || !config.telegramChatId) return;
 
   const bot = new Bot(config.telegramBotToken);
-  const { videoId, url, title, channelName, isShort } = params;
+  const { videoId, url, title, channelName, isShort, tags, description } = params;
+
+  const tagsPreview = formatTagsPreview(tags);
+  // Teaser: first line/sentence of the description, before any hashtag/CTA block,
+  // trimmed so the notification stays compact.
+  const teaserRaw = (description || "")
+    .split("\n")
+    .map((l) => l.trim())
+    .find((l) => l.length > 0 && !l.startsWith("#") && !l.startsWith("🎥") && !l.startsWith("🔗")) || "";
+  const teaser = teaserRaw.length > 180 ? `${teaserRaw.slice(0, 177)}...` : teaserRaw;
+
   // The YouTube thumbnail (i.ytimg.com) is often not generated yet immediately
   // after upload, so sendPhoto-by-URL fails with "wrong type of web page
   // content". Instead send a single message with the link preview ENABLED — the
@@ -34,6 +68,10 @@ export async function notifyYoutubePublished(
     `──────────────────────`,
     `📌 <b>${escapeHtml(title)}</b>`,
     channelName ? `📺 <b>Canal:</b> ${escapeHtml(channelName)}` : "",
+    teaser ? `` : "",
+    teaser ? `📝 <i>${escapeHtml(teaser)}</i>` : "",
+    tagsPreview ? `` : "",
+    tagsPreview ? `🏷 <b>Tags:</b> ${tagsPreview}` : "",
     ``,
     `🔗 <a href="${url}">${url}</a>`,
   ].filter(line => line !== "").join("\n");

--- a/src/core/youtube.service.ts
+++ b/src/core/youtube.service.ts
@@ -93,18 +93,40 @@ const capTagsToLimit = (tags: string[]): string[] => {
   return result;
 };
 
+// Build channel-derived keyword tags: the full channel name plus a couple of
+// adjacent word-pairs (handles "Nome Sobrenome Extra" → full + first-two +
+// last-two). Lowercased; punctuation that hurts YouTube search is stripped.
+const deriveChannelTags = (channelName: string | undefined): string[] => {
+  const name = (channelName || "").replace(/[|•·\-–—]+/g, " ").replace(/\s+/g, " ").trim();
+  if (!name) return [];
+  const tags = [name.toLowerCase()];
+  const words = name.split(" ").filter(Boolean);
+  if (words.length >= 2) {
+    tags.push(`${words[0]} ${words[1]}`.toLowerCase());
+    tags.push(`${words[words.length - 2]} ${words[words.length - 1]}`.toLowerCase());
+  }
+  return tags;
+};
+
 export const generateYoutubeMetadata = async (
   short: GeneratedShort,
   config: PipelineConfig
 ): Promise<{ title: string; description: string; tags: string[] }> => {
   const isEnabled = process.env.ENABLE_YOUTUBE === "true";
   const originalDescription = withOriginalVideoLink(short.clip.description, short.originalVideoUrl);
+  // Derive search tags from the source channel name (e.g. "Padre Paulo Ricardo"
+  // → "padre paulo ricardo", "padre paulo", "paulo ricardo") so even the
+  // AI-less fallback carries channel-relevant keywords.
+  const channelTags = deriveChannelTags(short.channelName);
   const defaultTags = [
+    ...channelTags,
+    ...(short.clip.hashtags || []).map((h) => h.replace(/^#/, "")),
+    ...(config.managedRun?.focusLabels || []),
     "shorts",
-    "curiosidades",
+    "cortes",
     "viral",
-    ...(short.clip.hashtags || []),
-    ...(config.managedRun?.focusLabels || [])
+    "curiosidades",
+    "melhores momentos",
   ];
 
   if (!isEnabled) {
@@ -141,18 +163,20 @@ Focos do canal de destino: ${config.managedRun?.focusLabels?.join(", ") || "não
 Transcrição do trecho/corte: "${clipTranscript}"
 
 INSTRUÇÕES PARA O TÍTULO:
-1. O título deve ser EXTREMAMENTE chamativo e instigante, com no máximo 60 caracteres, e incluir emojis. Use gatilhos mentais ou um "Hook" se fizer sentido.
-2. Identifique na Transcrição, no Título do Vídeo Original ou no Contexto o nome da pessoa envolvida (entrevistado, palestrante, convidado, influenciador, ou figura principal). O título do Short DEVE obrigatoriamente incluir o nome ou sobrenome dessa pessoa envolvida no vídeo (exemplo: "Padre Paulo Ricardo alertou sobre isso", "Tiago Brunet revela segredo", "Monja Coen ensina como acalmar"). Se NENHUMA pessoa for identificável, crie o título mais chamativo possível focado no assunto.
+1. O título deve ser EXTREMAMENTE chamativo e instigante, com no máximo 70 caracteres, e DEVE começar ou terminar com 1 ou 2 emojis relevantes ao tema (ex: 🔥, 😱, 🙏, 💡, ⚠️, ❤️). Use gatilhos mentais ou um "Hook" (curiosidade, polêmica, urgência, números) se fizer sentido.
+2. Identifique na Transcrição, no Título do Vídeo Original ou no Contexto o nome da pessoa que está FALANDO no vídeo (entrevistado, palestrante, convidado, influenciador, ou figura principal). O título do Short DEVE obrigatoriamente incluir o nome ou sobrenome dessa pessoa (exemplo: "🔥 Padre Paulo Ricardo alertou sobre isso", "😱 Tiago Brunet revela segredo", "🙏 Monja Coen ensina como acalmar a mente"). Se houver mais de uma pessoa, use a que conduz o trecho. Se NENHUMA pessoa for identificável, crie o título mais chamativo possível focado no assunto, ainda com emojis.
+3. NÃO use as palavras "corte", "clipe", "short", "vídeo", "parte" no título. Não use CAIXA ALTA na frase inteira.
 
 INSTRUÇÕES PARA A DESCRIÇÃO:
-1. A descrição deve ser completa e altamente engajadora em Português do Brasil (pt-BR).
-2. Escreva um resumo/teaser curto e instigante sobre o que é falado neste clipe (1 a 3 frases) para instigar a curiosidade e gerar retenção.
-3. Inclua obrigatoriamente uma chamada para ação (CTA) convidativa para engajar o público no canal (exemplo: "Inscreva-se no canal para não perder os próximos cortes! Deixe seu like e comente o que você achou.").
-4. O link do vídeo original completo DEVE ser inserido na descrição exatamente desta forma: "🎥 Vídeo original completo: ${short.originalVideoUrl}".
-5. Insira um bloco de hashtags ao final, incluindo: #shorts #viral, o nome da pessoa envolvida, o nome do canal/contexto e as hashtags sugeridas.
+1. A descrição deve ser completa e altamente engajadora em Português do Brasil (pt-BR), bem formatada com quebras de linha entre os blocos.
+2. Comece com um resumo/teaser curto e instigante sobre o que é falado neste clipe (2 a 4 frases) que gere curiosidade e retenção, citando o nome da pessoa que fala quando identificada.
+3. Em seguida, inclua de 3 a 5 tópicos curtos (bullets com "•" ou emojis) destacando os pontos altos do trecho.
+4. Inclua obrigatoriamente uma chamada para ação (CTA) convidativa (exemplo: "👉 Inscreva-se no canal para não perder os próximos cortes! Deixe seu like 👍 e comente o que você achou.").
+5. O link do vídeo original completo DEVE ser inserido na descrição exatamente desta forma: "🎥 Vídeo original completo: ${short.originalVideoUrl}".
+6. Termine com um bloco de 5 a 10 hashtags em uma única linha, incluindo: #shorts #viral, o nome da pessoa envolvida (sem espaços, ex: #PadrePauloRicardo), o nome do canal/contexto e as hashtags sugeridas.
 
 INSTRUÇÕES PARA AS TAGS (PALAVRAS-CHAVE):
-1. Gere a MAIOR quantidade possível de tags/palavras-chave de pesquisa relevantes (termos simples, sem #) para maximizar o alcance de busca no YouTube.
+1. Gere a MAIOR quantidade possível de tags/palavras-chave de pesquisa relevantes (termos simples em minúsculas, sem #) para maximizar o alcance de busca no YouTube.
 2. Gere pelo menos 30 tags cobrindo:
    - O nome completo e variações do nome da pessoa envolvida no vídeo.
    - O nome do canal e termos relacionados ao canal original.
@@ -174,7 +198,7 @@ O texto deve estar EXCLUSIVAMENTE em Português do Brasil. NÃO use inglês de f
       model: createModel(config),
       prompt,
       temperature: 0.5,
-      maxOutputTokens: 700,
+      maxOutputTokens: 1100,
       maxRetries: 5,
     });
 
@@ -286,7 +310,15 @@ async function performUpload(
     if (url && videoId) {
       logger.info({ url }, "✅ Vídeo enviado com sucesso para o YouTube!");
       await notifyYoutubePublished(
-        { videoId, url, title: requestBody.snippet.title, channelName: config.managedRun?.channelName, isShort: !!isShort },
+        {
+          videoId,
+          url,
+          title: requestBody.snippet.title,
+          channelName: config.managedRun?.channelName,
+          isShort: !!isShort,
+          tags: requestBody.snippet.tags,
+          description: requestBody.snippet.description,
+        },
         config,
       );
     }
@@ -423,7 +455,8 @@ export const uploadFullVideoToYouTube = async (
   videoPath: string,
   title: string,
   description: string,
-  config: PipelineConfig
+  config: PipelineConfig,
+  tags?: string[]
 ): Promise<string | null> => {
   if (process.env.ENABLE_YOUTUBE !== "true") return null;
 
@@ -440,12 +473,20 @@ export const uploadFullVideoToYouTube = async (
     return null;
   }
 
+  const uploadTags = limitTagsLength(
+    tags && tags.length > 0
+      ? tags
+      : ["viral", "curiosidades", ...config.managedRun?.focusLabels ?? []],
+    490
+  );
+
   return performUpload(
     videoPath,
     {
       snippet: {
         title: title.slice(0, 100),
         description,
+        tags: uploadTags,
         categoryId: "22", // People & Blogs
       },
       status: {

--- a/tests/core/youtube.service.test.ts
+++ b/tests/core/youtube.service.test.ts
@@ -150,7 +150,7 @@ describe("youtube.service", () => {
       expect(result).toEqual({
         title: "Original Title",
         description: "Original Description",
-        tags: ["shorts", "curiosidades", "viral", "#dummy"],
+        tags: ["dummy channel", "dummy", "shorts", "cortes", "viral", "curiosidades", "melhores momentos"],
       });
     });
 
@@ -165,7 +165,7 @@ describe("youtube.service", () => {
       expect(result).toEqual({
         title: "Viral Title",
         description: "Viral Description",
-        tags: ["shorts", "curiosidades", "viral", "#dummy"],
+        tags: ["dummy channel", "dummy", "shorts", "cortes", "viral", "curiosidades", "melhores momentos"],
       });
     });
 
@@ -182,7 +182,7 @@ describe("youtube.service", () => {
       const result = await generateYoutubeMetadata(mockShort, config);
 
       expect(result.title).toBe("Viral Title");
-      expect(result.tags).toEqual(["shorts", "curiosidades", "viral", "#dummy"]);
+      expect(result.tags).toEqual(["shorts", "dummy channel", "dummy", "cortes", "viral", "curiosidades", "melhores momentos"]);
     });
 
     it("should pass the transcript in the AI prompt", async () => {
@@ -197,9 +197,9 @@ describe("youtube.service", () => {
 
 
     it.each([
-      { content: 'invalid json', expected: { title: "Original Title", description: "Original Description", tags: ["shorts", "curiosidades", "viral", "#dummy"] } },
-      { content: '{"description": "Viral Description"}', expected: { title: "Original Title", description: "Viral Description", tags: ["shorts", "curiosidades", "viral", "#dummy"] } },
-      { content: '{"title": "Viral Title"}', expected: { title: "Viral Title", description: "Original Description", tags: ["shorts", "curiosidades", "viral", "#dummy"] } }
+      { content: 'invalid json', expected: { title: "Original Title", description: "Original Description", tags: ["dummy channel", "dummy", "shorts", "cortes", "viral", "curiosidades", "melhores momentos"] } },
+      { content: '{"description": "Viral Description"}', expected: { title: "Original Title", description: "Viral Description", tags: ["dummy channel", "dummy", "shorts", "cortes", "viral", "curiosidades", "melhores momentos"] } },
+      { content: '{"title": "Viral Title"}', expected: { title: "Viral Title", description: "Original Description", tags: ["dummy channel", "dummy", "shorts", "cortes", "viral", "curiosidades", "melhores momentos"] } }
     ])("should fallback properly when JSON parsing fails or misses fields: $content", async ({ content, expected }) => {
       setupMock(content);
       const result = await generateYoutubeMetadata(mockShort, mockConfig);
@@ -213,7 +213,7 @@ describe("youtube.service", () => {
       expect(result).toEqual({
         title: "Original Title",
         description: "Original Description",
-        tags: ["shorts", "curiosidades", "viral", "#dummy"],
+        tags: ["dummy channel", "dummy", "shorts", "cortes", "viral", "curiosidades", "melhores momentos"],
       });
     });
   });


### PR DESCRIPTION
- Telegram: notificação de publicação no YouTube agora exibe um teaser
  da descrição e as tags de busca aplicadas no upload
- YouTube: descrições mais ricas (teaser, bullets, CTA, link original,
  bloco de hashtags) e títulos com emojis + nome de quem fala no vídeo
- Tags: derivadas do nome do canal + variações, mais termos amplos;
  fallback sem IA agora carrega keywords relevantes
- Vídeo completo (generate:top): descrição engajadora e tags de busca
  passadas ao upload, refletidas na notificação do Telegram

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_0127t2xev3wTDDskGXJ11TVA