### PR TITLE
feat: títulos com nome do apresentador e enquadramento centrado no orador

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -35,6 +35,12 @@ TELEGRAM_CHAT_ID=-1001234567890
 # ─── Watermark text for generated shorts ───
 WATERMARK_TEXT="santidade católica"
 
+# ─── Speaker-centered framing ───
+# When "true" (default), the vertical crop is biased toward the main speaker's
+# face (requires Python + opencv-python; falls back to a centered crop when
+# unavailable). Set to "false" to always center-crop.
+SPEAKER_FOCUS=true
+
 # ─── Output Directory for generated shorts ───
 OUTPUT_DIR=./output
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -78,6 +78,7 @@ The pipeline requires these system tools at runtime:
 - **yt-dlp** — YouTube video download
 - **OpenAI Whisper** (Python) — audio transcription
 - **LiteLLM** — OpenAI-compatible LLM gateway (must be reachable at `LITELLM_BASE_URL`)
+- **opencv-python** (Python, optional) — speaker-centered framing (`scripts/detect_face.py`); when absent the crop falls back to centered (toggled by `SPEAKER_FOCUS`)
 
 ### Code Constraints (Antigravity Protocol)
 

--- a/scripts/detect_face.py
+++ b/scripts/detect_face.py
@@ -1,0 +1,67 @@
+#!/usr/bin/env python3
+"""Detect the dominant speaker's horizontal position in a video clip.
+
+Samples a handful of frames across the requested time window and reports the
+median horizontal center (0.0 = left edge, 1.0 = right edge) of the largest
+detected face. Prints a single float to stdout. On any failure (missing
+OpenCV, no faces, unreadable video) it prints nothing and exits non‑zero so the
+caller can fall back to a centered crop.
+
+Usage: detect_face.py <input> <start_seconds> <duration_seconds>
+"""
+import sys
+
+
+def main() -> int:
+    if len(sys.argv) < 4:
+        return 1
+    path = sys.argv[1]
+    start = float(sys.argv[2])
+    duration = float(sys.argv[3])
+
+    try:
+        import cv2  # type: ignore
+    except Exception:
+        return 1
+
+    cap = cv2.VideoCapture(path)
+    if not cap.isOpened():
+        return 1
+
+    cascade_path = cv2.data.haarcascades + "haarcascade_frontalface_default.xml"
+    cascade = cv2.CascadeClassifier(cascade_path)
+    if cascade.empty():
+        cap.release()
+        return 1
+
+    samples = 9
+    centers = []
+    for i in range(samples):
+        ts = start + (duration * (i + 0.5) / samples)
+        cap.set(cv2.CAP_PROP_POS_MSEC, ts * 1000.0)
+        ok, frame = cap.read()
+        if not ok or frame is None:
+            continue
+        h, w = frame.shape[:2]
+        if w == 0:
+            continue
+        gray = cv2.cvtColor(frame, cv2.COLOR_BGR2GRAY)
+        faces = cascade.detectMultiScale(gray, scaleFactor=1.1, minNeighbors=5,
+                                         minSize=(60, 60))
+        if len(faces) == 0:
+            continue
+        # Largest face wins (closest / main speaker).
+        fx, fy, fw, fh = max(faces, key=lambda r: r[2] * r[3])
+        centers.append((fx + fw / 2.0) / w)
+
+    cap.release()
+    if not centers:
+        return 1
+    centers.sort()
+    median = centers[len(centers) // 2]
+    print(f"{max(0.0, min(1.0, median)):.4f}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/core/analyzer-schema.ts
+++ b/src/core/analyzer-schema.ts
@@ -2,6 +2,7 @@ import { z } from "zod";
 
 export const ClipItemSchema = z.object({
   title: z.string().describe("Título chamativo e relevante para o trecho"),
+  presenter: z.string().optional().describe("Nome (ou sobrenome) da pessoa que está falando/apresentando neste trecho, se identificável. Deixe vazio se desconhecido."),
   description: z.string().describe("Breve resumo do conteúdo deste clipe"),
   contentValue: z.string().describe("Explique o valor deste trecho (ex: uma oração, um ensinamento, uma reflexão profunda)"),
   startTime: z.number().describe("Tempo de início em segundos"),

--- a/src/core/analyzer.ts
+++ b/src/core/analyzer.ts
@@ -192,6 +192,8 @@ PONTUAÇÃO viralScore (1-10):
 
 Títulos em Português (pt-BR), máx 50 caracteres, sem: "corte", "clipe", "short", "vídeo", "canal", "parte".
 
+APRESENTADOR: identifique no título do vídeo, no nome do canal ou na própria transcrição o nome (ou sobrenome) da pessoa que está FALANDO/apresentando neste trecho e preencha o campo "presenter". Se houver mais de uma pessoa, use a que conduz o trecho. Se não for possível identificar com segurança, deixe "presenter" vazio.
+
 TRANSCRIÇÃO:
 ${transcript}`;
 }
@@ -225,6 +227,7 @@ function processClips(clips: ClipItem[], transcript: Transcript, config: Pipelin
         id: nanoid(10),
         videoId: transcript.videoId,
         title: clip.title,
+        presenter: clip.presenter?.trim() || undefined,
         description: clip.description,
         startTime: snapped.startTime,
         endTime: snapped.endTime,

--- a/src/core/face-framing.ts
+++ b/src/core/face-framing.ts
@@ -1,0 +1,51 @@
+import { execFile } from "node:child_process";
+import fs from "node:fs";
+import path from "node:path";
+import { promisify } from "node:util";
+import type { ShortClip } from "../types.js";
+import { logger } from "./logger.js";
+
+const execFileAsync = promisify(execFile);
+
+/** Centered crop. Used when detection is disabled or fails. */
+export const CENTER_FOCUS = 0.5;
+
+function detectScriptPath(): string {
+  return path.resolve(process.cwd(), "scripts", "detect_face.py");
+}
+
+/**
+ * Find the horizontal position (0=left, 1=right) of the main speaker's face
+ * within a clip so the vertical crop can keep them framed. Best-effort: returns
+ * {@link CENTER_FOCUS} when speaker focusing is disabled, the helper is missing,
+ * OpenCV is unavailable, or no face is found — preserving the centered crop.
+ */
+export async function detectSpeakerFocusX(
+  inputPath: string,
+  clip: Pick<ShortClip, "startTime" | "duration">,
+): Promise<number> {
+  if (process.env.SPEAKER_FOCUS === "false") return CENTER_FOCUS;
+
+  const script = detectScriptPath();
+  if (!fs.existsSync(script)) return CENTER_FOCUS;
+
+  const python = process.env.PYTHON_BIN || "python3";
+  try {
+    const { stdout } = await execFileAsync(
+      python,
+      [script, inputPath, String(clip.startTime), String(clip.duration)],
+      { timeout: 60_000, maxBuffer: 4 * 1024 * 1024 },
+    );
+    const value = Number.parseFloat(String(stdout).trim());
+    if (!Number.isFinite(value)) return CENTER_FOCUS;
+    const focusX = Math.max(0, Math.min(1, value));
+    logger.info({ inputPath, focusX }, "Speaker face detected, biasing crop");
+    return focusX;
+  } catch (err) {
+    logger.debug(
+      { err: err instanceof Error ? err.message : String(err) },
+      "Speaker face detection unavailable, using centered crop",
+    );
+    return CENTER_FOCUS;
+  }
+}

--- a/src/core/presenter-title.ts
+++ b/src/core/presenter-title.ts
@@ -8,6 +8,8 @@ export function buildPresenterTitle(title: string, presenter?: string | null): s
   const name = (presenter ?? "").trim();
   const base = (title ?? "").trim();
   if (!name) return base;
-  if (base.toLowerCase().includes(name.toLowerCase())) return base;
-  return `${name}: ${base}`;
+  const escapedName = name.replace(/[-\/\\^$*+?.()|[\]{}]/g, "\\$&");
+  const regex = new RegExp("(?<![\\p{L}\\p{N}])" + escapedName + "(?![\\p{L}\\p{N}])", "ui");
+  if (regex.test(base)) return base;
+  return name + ": " + base;
 }

--- a/src/core/presenter-title.ts
+++ b/src/core/presenter-title.ts
@@ -1,0 +1,13 @@
+/**
+ * Build a presenter-aware title. When a presenter name is identified and is not
+ * already part of the title, prefix it so the speaker becomes the highlight
+ * (e.g. "Padre Paulo Ricardo: O segredo da oração"). Falls back to the raw
+ * title when no presenter is known or it is already mentioned.
+ */
+export function buildPresenterTitle(title: string, presenter?: string | null): string {
+  const name = (presenter ?? "").trim();
+  const base = (title ?? "").trim();
+  if (!name) return base;
+  if (base.toLowerCase().includes(name.toLowerCase())) return base;
+  return `${name}: ${base}`;
+}

--- a/src/core/short-renderer.ts
+++ b/src/core/short-renderer.ts
@@ -6,6 +6,7 @@ import { promisify } from "node:util";
 import ffmpeg from "fluent-ffmpeg";
 import type { PipelineConfig, ShortClip } from "../types.js";
 import { logger } from "./logger.js";
+import { CENTER_FOCUS, detectSpeakerFocusX } from "./face-framing.js";
 
 const execFileAsync = promisify(execFile);
 
@@ -35,9 +36,14 @@ export function buildSafeFramingFilter(
   width: number,
   height: number,
   logoPath?: string | null,
+  focusX: number = CENTER_FOCUS,
 ): string {
   const assPath = escapeFilterPath(subtitlePath);
-  const baseVideo = `[0:v]scale=w='if(gt(iw/ih,${width}/${height}),-1,${width})':h='if(gt(iw/ih,${width}/${height}),${height},-1)':flags=lanczos+accurate_rnd,crop=${width}:${height},hqdn3d=1.5:1.5:3:3,unsharp=3:3:0.5:3:3:0.5,setsar=1,ass='${assPath}'[base]`;
+  // Horizontal crop offset biased toward the speaker (focusX in [0,1]); clamped
+  // so the crop window never leaves the frame. focusX=0.5 yields a centered crop.
+  const fx = Math.max(0, Math.min(1, focusX)).toFixed(4);
+  const cropX = `'clip((in_w*${fx})-(${width}/2)\\,0\\,in_w-${width})'`;
+  const baseVideo = `[0:v]scale=w='if(gt(iw/ih,${width}/${height}),-1,${width})':h='if(gt(iw/ih,${width}/${height}),${height},-1)':flags=lanczos+accurate_rnd,crop=${width}:${height}:${cropX}:(in_h-${height})/2,hqdn3d=1.5:1.5:3:3,unsharp=3:3:0.5:3:3:0.5,setsar=1,ass='${assPath}'[base]`;
   if (!logoPath) {
     return `${baseVideo};[base]copy[v]`;
   }
@@ -54,11 +60,13 @@ export async function renderShort(
   const logoPath = config.managedRun?.logoPath && fs.existsSync(config.managedRun.logoPath)
     ? config.managedRun.logoPath
     : null;
+  const focusX = await detectSpeakerFocusX(inputPath, clip);
   const filter = buildSafeFramingFilter(
     subtitlePath,
     config.verticalWidth,
     config.verticalHeight,
     logoPath,
+    focusX,
   );
   const isNvenc = config.videoEncoder.includes("nvenc");
   const qualityArgs = isNvenc ? ["-cq", "18"] : ["-crf", "18"];

--- a/src/core/telegram.ts
+++ b/src/core/telegram.ts
@@ -4,6 +4,7 @@ import fs from "node:fs";
 import type { GeneratedShort, PipelineConfig } from "../types.js";
 import { logger } from "./logger.js";
 import { withRetry } from "./retry-backoff.js";
+import { buildPresenterTitle } from "./presenter-title.js";
 
 function escapeHtml(text: string): string {
   if (!text) return "";
@@ -243,11 +244,15 @@ export async function sendToTelegram(
 
   const timeRange = `${startMin}:${startSec.toString().padStart(2, "0")} - ${endMin}:${endSec.toString().padStart(2, "0")}`;
 
+  const presenter = short.clip.presenter?.trim();
+  const displayTitle = buildPresenterTitle(short.clip.title, presenter);
+
   const caption = [
     `✂️ <b>NOVO SHORT GERADO</b>`,
     `──────────────────────`,
-    `🎬 <b>${escapeHtml(short.clip.title)}</b>`,
+    `🎬 <b>${escapeHtml(displayTitle)}</b>`,
     ``,
+    presenter ? `🎤 <b>Apresentador:</b> ${escapeHtml(presenter)}` : "",
     `📺 <b>Canal:</b> ${escapeHtml(short.channelName)}`,
     `🎥 <b>Original:</b> ${escapeHtml(short.originalVideoTitle)}`,
     `⏱ <b>Corte:</b> <code>${timeRange}</code>`,

--- a/src/core/youtube.service.ts
+++ b/src/core/youtube.service.ts
@@ -4,6 +4,7 @@ import { generateText } from "ai";
 import type { GeneratedShort, PipelineConfig, YouTubeAuthConfig } from "../types.js";
 import { logger } from "./logger.js";
 import { createModel } from "./ai-provider.js";
+import { buildPresenterTitle } from "./presenter-title.js";
 import { withRetry } from "./retry-backoff.js";
 import { isDailyLimitReachedAsync, setDailyLimitReachedAsync } from "./state.js";
 import { sendErrorAlert, notifyYoutubePublished, notifyYoutubeRateLimited } from "./telegram.js";
@@ -131,7 +132,7 @@ export const generateYoutubeMetadata = async (
 
   if (!isEnabled) {
     return {
-      title: short.clip.title,
+      title: buildPresenterTitle(short.clip.title, short.clip.presenter),
       description: originalDescription,
       tags: capTagsToLimit(defaultTags),
     };
@@ -140,7 +141,7 @@ export const generateYoutubeMetadata = async (
   /* v8 ignore start */
   if (process.env.SKIP_AI_METADATA === "true") {
     return {
-      title: short.clip.title,
+      title: buildPresenterTitle(short.clip.title, short.clip.presenter),
       description: originalDescription,
       tags: capTagsToLimit(defaultTags),
     };
@@ -154,6 +155,7 @@ export const generateYoutubeMetadata = async (
 
   const prompt = `Crie um título, uma descrição e tags/palavras-chave OTIMIZADOS para o YouTube Shorts para o seguinte corte de vídeo:
 Título Sugerido do Corte: ${short.clip.title}
+Apresentador identificado: ${short.clip.presenter || "não informado"}
 Título do Vídeo Original: ${short.originalVideoTitle}
 Descrição Sugerida do Corte: ${short.clip.description}
 Contexto/Canal de Origem: ${short.channelName}
@@ -213,7 +215,7 @@ O texto deve estar EXCLUSIVAMENTE em Português do Brasil. NÃO use inglês de f
   } catch (error) {
     logger.error({ error, clipId: short.id }, "Erro ao gerar metadados para o YouTube");
     return {
-      title: short.clip.title,
+      title: buildPresenterTitle(short.clip.title, short.clip.presenter),
       description: originalDescription,
       tags: capTagsToLimit(defaultTags),
     };

--- a/src/types.ts
+++ b/src/types.ts
@@ -45,6 +45,8 @@ export interface ShortClip {
   id: string;
   videoId: string;
   title: string;
+  /** Name of the person presenting/speaking in this clip, when identifiable */
+  presenter?: string;
   description: string;
   startTime: number;
   endTime: number;

--- a/tests/core/face-framing.test.ts
+++ b/tests/core/face-framing.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
+import { execFile } from "node:child_process";
+import fs from "node:fs";
+import { detectSpeakerFocusX, CENTER_FOCUS } from "../../src/core/face-framing.js";
+
+vi.mock("node:child_process", () => ({ execFile: vi.fn() }));
+vi.mock("node:fs", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("node:fs")>();
+  return { default: { ...actual, existsSync: vi.fn() } };
+});
+
+const clip = { startTime: 10, duration: 20 };
+
+function mockExec(result: { stdout?: string; err?: Error }) {
+  vi.mocked(execFile).mockImplementation((_f: any, _a: any, _o: any, cb?: any) => {
+    const done = cb || _o;
+    if (result.err) done(result.err, { stdout: "", stderr: "" });
+    else done(null, { stdout: result.stdout ?? "", stderr: "" });
+    return {} as any;
+  });
+}
+
+describe("detectSpeakerFocusX", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    delete process.env.SPEAKER_FOCUS;
+    vi.mocked(fs.existsSync).mockReturnValue(true);
+  });
+  afterEach(() => {
+    delete process.env.SPEAKER_FOCUS;
+  });
+
+  it("returns the detected focus when the helper reports a face position", async () => {
+    mockExec({ stdout: "0.7200\n" });
+    expect(await detectSpeakerFocusX("in.mp4", clip)).toBeCloseTo(0.72);
+  });
+
+  it("falls back to center when detection is disabled", async () => {
+    process.env.SPEAKER_FOCUS = "false";
+    expect(await detectSpeakerFocusX("in.mp4", clip)).toBe(CENTER_FOCUS);
+    expect(execFile).not.toHaveBeenCalled();
+  });
+
+  it("falls back to center when the helper script is missing", async () => {
+    vi.mocked(fs.existsSync).mockReturnValue(false);
+    expect(await detectSpeakerFocusX("in.mp4", clip)).toBe(CENTER_FOCUS);
+    expect(execFile).not.toHaveBeenCalled();
+  });
+
+  it("falls back to center when the helper fails", async () => {
+    mockExec({ err: new Error("no cv2") });
+    expect(await detectSpeakerFocusX("in.mp4", clip)).toBe(CENTER_FOCUS);
+  });
+
+  it("falls back to center on non-numeric output", async () => {
+    mockExec({ stdout: "" });
+    expect(await detectSpeakerFocusX("in.mp4", clip)).toBe(CENTER_FOCUS);
+  });
+
+  it("clamps out-of-range values into [0,1]", async () => {
+    mockExec({ stdout: "1.9" });
+    expect(await detectSpeakerFocusX("in.mp4", clip)).toBe(1);
+  });
+});

--- a/tests/core/presenter-title.test.ts
+++ b/tests/core/presenter-title.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from "vitest";
+import { buildPresenterTitle } from "../../src/core/presenter-title.js";
+
+describe("buildPresenterTitle", () => {
+  it("prefixes the presenter name when not already present", () => {
+    expect(buildPresenterTitle("O segredo da oração", "Padre Paulo Ricardo"))
+      .toBe("Padre Paulo Ricardo: O segredo da oração");
+  });
+
+  it("returns the raw title when no presenter is provided", () => {
+    expect(buildPresenterTitle("O segredo da oração")).toBe("O segredo da oração");
+    expect(buildPresenterTitle("O segredo da oração", "")).toBe("O segredo da oração");
+    expect(buildPresenterTitle("O segredo da oração", null)).toBe("O segredo da oração");
+  });
+
+  it("does not duplicate the name when already in the title", () => {
+    expect(buildPresenterTitle("Padre Paulo revela tudo", "Padre Paulo"))
+      .toBe("Padre Paulo revela tudo");
+    expect(buildPresenterTitle("PADRE PAULO revela", "padre paulo"))
+      .toBe("PADRE PAULO revela");
+  });
+
+  it("trims surrounding whitespace", () => {
+    expect(buildPresenterTitle("  Título  ", "  Fulano  ")).toBe("Fulano: Título");
+  });
+});

--- a/tests/core/presenter-title.test.ts
+++ b/tests/core/presenter-title.test.ts
@@ -23,4 +23,8 @@ describe("buildPresenterTitle", () => {
   it("trims surrounding whitespace", () => {
     expect(buildPresenterTitle("  Título  ", "  Fulano  ")).toBe("Fulano: Título");
   });
+
+  it("prefixes the presenter name even if it is a substring of a word in the title", () => {
+    expect(buildPresenterTitle("Semana de oração", "Ana")).toBe("Ana: Semana de oração");
+  });
 });

--- a/tests/core/short-renderer.test.ts
+++ b/tests/core/short-renderer.test.ts
@@ -34,6 +34,22 @@ describe("short-renderer", () => {
     expect(filter).toContain("ass='C\\:/tmp/clip.ass'");
   });
 
+  it("buildSafeFramingFilter centers the crop by default", () => {
+    const filter = buildSafeFramingFilter("clip.ass", 1080, 1920);
+    expect(filter).toContain("crop=1080:1920:'clip((in_w*0.5000)-(1080/2)");
+    expect(filter).toContain(":(in_h-1920)/2,");
+  });
+
+  it("buildSafeFramingFilter biases the crop toward the detected speaker", () => {
+    const filter = buildSafeFramingFilter("clip.ass", 1080, 1920, null, 0.75);
+    expect(filter).toContain("crop=1080:1920:'clip((in_w*0.7500)-(1080/2)");
+  });
+
+  it("buildSafeFramingFilter clamps the focus into [0,1]", () => {
+    expect(buildSafeFramingFilter("clip.ass", 1080, 1920, null, 2)).toContain("in_w*1.0000");
+    expect(buildSafeFramingFilter("clip.ass", 1080, 1920, null, -1)).toContain("in_w*0.0000");
+  });
+
   it("buildSafeFramingFilter includes logo overlay when logoPath is provided", () => {
     const filter = buildSafeFramingFilter("C:\\tmp\\clip.ass", 1080, 1920, "/logos/wm.png");
     expect(filter).toContain("[1:v]scale=180:-1[logo]");

--- a/tests/core/telegram.test.ts
+++ b/tests/core/telegram.test.ts
@@ -65,6 +65,21 @@ describe("telegram", () => {
     expect(result).toBe(123);
   });
 
+  it("should include the presenter name in caption and title", async () => {
+    vi.mocked(fs.statSync).mockReturnValue({ size: 10 * 1024 * 1024 } as any);
+    mockSendVideo.mockResolvedValue({ message_id: 321 });
+    const withPresenter: GeneratedShort = {
+      ...mockShort,
+      clip: { title: "O segredo da fé", description: "Desc", hashtags: ["#tag"], presenter: "Padre Paulo" } as ShortClip,
+    };
+    await sendToTelegram(withPresenter, mockConfig);
+
+    const caption = mockSendVideo.mock.calls[0][2].caption as string;
+    expect(caption).toContain("Padre Paulo: O segredo da fé");
+    expect(caption).toContain("Apresentador:");
+    expect(caption).toContain("Padre Paulo");
+  });
+
   it("should send text message if video is too large", async () => {
     vi.mocked(fs.statSync).mockReturnValue({ size: 60 * 1024 * 1024 } as any);
     mockSendMessage.mockResolvedValue({ message_id: 999 });

--- a/tests/core/video-processor.test.ts
+++ b/tests/core/video-processor.test.ts
@@ -121,7 +121,10 @@ describe("video-processor", () => {
 
       const execFileCalls = vi.mocked(execFile).mock.calls;
       expect(execFileCalls.length).toBeGreaterThan(0);
-      const args = execFileCalls[0][1] as string[];
+      // The speaker-focus detection may run first; locate the ffmpeg render call.
+      const ffmpegCall = execFileCalls.find((c) => (c[1] as string[]).includes("-filter_complex"));
+      expect(ffmpegCall).toBeDefined();
+      const args = ffmpegCall![1] as string[];
       const filterArgIndex = args.indexOf("-filter_complex");
       expect(filterArgIndex).toBeGreaterThan(-1);
       expect(args[filterArgIndex + 1]).toContain("crop=1080:1920");


### PR DESCRIPTION
## Resumo

Melhora as mensagens enviadas ao Telegram destacando **quem está apresentando** e centraliza o vídeo no orador.

### 1. Nome do apresentador no título
- Novo campo `presenter` em `ShortClip` + schema/prompt do analyzer para a IA identificar quem está falando no trecho (a partir do título original, nome do canal ou da própria transcrição).
- Helper `buildPresenterTitle()` prefixa o nome ao título quando ainda não estiver presente (ex: `Padre Paulo Ricardo: O segredo da oração`).
- Aplicado na legenda do short no Telegram (com nova linha `🎤 Apresentador:`) e reutilizado nos fallbacks de metadados do YouTube; o nome também é passado ao prompt de metadados.

### 2. Enquadramento centrado no orador
- `scripts/detect_face.py` (OpenCV) amostra frames ao longo do corte e reporta a posição horizontal do rosto principal.
- `face-framing.ts` invoca o script de forma *best-effort*; o crop vertical é deslocado para manter o orador em destaque.
- Degrada graciosamente para crop centralizado quando a detecção está desativada ou indisponível, controlado pela env `SPEAKER_FOCUS` (padrão `true`).

## Homologação
- `pnpm build` (type-check) ✅
- `pnpm test` — 330 testes passando ✅
- Novos testes: `presenter-title.test.ts`, `face-framing.test.ts`, cobertura adicional em `short-renderer` e `telegram`.

## Notas
- A detecção de rosto exige `opencv-python`; quando ausente, o comportamento atual (crop centralizado) é preservado.
- `SPEAKER_FOCUS` documentado em `.env.example` e `CLAUDE.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01BDprqSjypBr6KYN6ipGrhi)_